### PR TITLE
Add missing constructor for registering id

### DIFF
--- a/src/main/java/fun/lewisdev/tournaments/objective/XLObjective.java
+++ b/src/main/java/fun/lewisdev/tournaments/objective/XLObjective.java
@@ -7,6 +7,8 @@ import org.bukkit.entity.Player;
 import java.util.*;
 
 public abstract class XLObjective {
+    
+    public XLObjective(String var) {}
 
     public abstract boolean loadTournament(FileConfiguration config);
 


### PR DESCRIPTION
The API is missing an essential method for registering the tournament ID